### PR TITLE
fix: callback tracking reference due to closure

### DIFF
--- a/src/useClickOutside.ts
+++ b/src/useClickOutside.ts
@@ -10,26 +10,28 @@ type HookConfig = {
 
 export const useClickOutside = <T = View>(callback: () => void, config?: HookConfig): React.RefObject<T> => {
   const callbackRef = React.useRef(callback);
+  callbackRef.current = callback;
+  const callbackRegisterWrapper = () => callbackRef.current();
+
   const ref = React.useRef<T>(null);
 
   useFocusEffect(
     () => {
       if (config?.triggerOnBlur === false) return;
-      register(ref, callbackRef.current);
+      register(ref, callbackRegisterWrapper);
     },
     () => {
       if (config?.triggerOnBlur === false) return;
-      callbackRef.current();
+      callbackRegisterWrapper();
       unregister(ref);
     }
   );
   React.useEffect(() => {
-    register(ref, callbackRef.current);
+    register(ref, callbackRegisterWrapper);
     return () => {
       unregister(ref);
       if (config?.triggerOnUnmount === false) return;
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      callbackRef.current();
+      callbackRegisterWrapper();
     };
   }, [config?.triggerOnUnmount]);
 


### PR DESCRIPTION
## Issue: 

 callback references are registered once the component mount & because of closures new the new updated callback that depends on other values will be ignored

https://www.loom.com/share/05117b4f7aa740149d775e3cd29c2ce4

## Fix:
https://www.loom.com/share/8f54d770da6d4d638986de543e102559