### PR TITLE
Add children type for ClickOutsideProviderProps

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -6,7 +6,7 @@ import { isInRange } from './utils/helpers';
 type ClickOutsideProviderProps = {
   activateOnSwipe?: boolean;
   swipeThreshold?: number;
-  children: JSX.Element;
+  children: React.ReactNode;
 };
 
 let touchX: number | undefined;

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -6,6 +6,7 @@ import { isInRange } from './utils/helpers';
 type ClickOutsideProviderProps = {
   activateOnSwipe?: boolean;
   swipeThreshold?: number;
+  children: JSX.Element;
 };
 
 let touchX: number | undefined;


### PR DESCRIPTION
Fixes this problem

![image](https://github.com/jakex7/react-native-click-outside/assets/44204622/0d6ac8f8-4dd3-4511-a761-f348a606c5da)
